### PR TITLE
Examiner does not check the validity of input JavaSource

### DIFF
--- a/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
+++ b/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
@@ -239,6 +239,9 @@ public abstract class Examiner {
    protected static String jumpOverJavaToken(String token, Scanner scanner) {
       String nextToken = token;
       while (isAJavaToken(nextToken)) {
+         if (!scanner.hasNext()) {
+            throw new IllegalArgumentException("Insufficient number of tokens to jump over");
+         }
          if (nextToken.startsWith("@") && nextToken.indexOf('(') > -1 && !nextToken.endsWith(")")) {
             nextToken = scanAfterClosedParenthesis(nextToken, scanner);
          } else {

--- a/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
+++ b/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
@@ -310,6 +310,27 @@ public class ExaminerTest {
    }
 
    @Test
+   public void testJumpOverTokenInsufficientTokens(){
+      JavaSource javaSource;
+      String sourceCode;
+      String actual;
+      String expected;
+      Scanner scanner;
+      String currentToken;
+
+      javaSource = new JavaSource("TestClass");
+      sourceCode = "public";
+      javaSource.setSourceCode(sourceCode);
+      scanner = Examiner.getSourceCodeScanner(javaSource.getSourceCode());
+      currentToken = scanner.next(); // now public
+      try {
+          actual = ExaminerImpl.jumpOverJavaToken(currentToken, scanner);
+      } catch (IllegalArgumentException iae) {
+          assertEquals("Insufficient number of tokens to jump over", iae.getMessage());
+      }
+   }
+
+   @Test
    public void testCleanupGeneric() {
       String inputString;
       String actual;


### PR DESCRIPTION
Examiner.java calls 'scanner.next()' on 'java.util.Scanner scanner' without checking
if there are more elements.  Because the scanner is built from the JavaSource parameter
that can be invalid (e.g., an empty source), this can lead to a runtime exception
without a useful error message.  This pull request adds an error message and a test.