### PR TITLE
Examiner does not check the validity of input JavaSource

### DIFF
--- a/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
+++ b/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
@@ -256,6 +256,9 @@ public abstract class Examiner {
       while (scanner.hasNext()) {
          String token = scanner.next();
          if (javaSource.getPackagePath() == null && token.equals("package")) {
+            if (!scanner.hasNext()) {
+               throw new IllegalArgumentException("Insufficient number of tokens to set package");
+            }
             token = scanner.next();
             if (token.endsWith(";")) {
                String packagePath = token.substring(0, token.indexOf(';'));

--- a/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
+++ b/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
@@ -388,6 +388,21 @@ public class ExaminerTest {
       assertEquals("de.test1.test2.test3.test4", javaSource.getPackagePath());
    }
 
+   @Test
+   public void testFindAndSetPackageInsufficientTokens() {
+      JavaSource javaSource;
+      String sourceCode;
+
+      javaSource = new JavaSource("MyTestClass");
+      sourceCode = "package";
+      javaSource.setSourceCode(sourceCode);
+      try{
+          Examiner.findAndSetPackage(javaSource);
+      } catch (IllegalArgumentException iae) {
+          assertEquals("Insufficient number of tokens to set package", iae.getMessage());
+      }
+   }
+
    public class ExaminerImpl extends Examiner {
 
       @Override


### PR DESCRIPTION
In Examiner.java:259, 'scanner.next()' is called on 'java.util.Scanner scanner' without checking
if there are more elements. Because the scanner is built from the JavaSource parameter
that can be invalid (e.g., package keyword followed by an empty package name), this can lead to a runtime exception without a useful error message. This pull request adds an error message and a test.