### PR TITLE
 Examiner does not check the validity of input JavaSource

### DIFF
--- a/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
+++ b/src/main/java/de/strullerbaumann/visualee/examiner/Examiner.java
@@ -141,6 +141,9 @@ public abstract class Examiner {
       for (int iCount = 0; iCount < countParenthesisOpen - countParenthesisClose; iCount++) {
          stack.push(1);
       }
+      if (!scanner.hasNext()) {
+         throw new IllegalArgumentException("Insufficient number of tokens to scan after closed parenthesis");
+      }
       String token = scanner.next();
 
       whilestack:

--- a/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
+++ b/src/test/java/de/strullerbaumann/visualee/examiner/ExaminerTest.java
@@ -280,6 +280,25 @@ public class ExaminerTest {
    }
 
    @Test
+   public void testScanAfterClosedParenthesisInsufficientTokens() {
+      JavaSource javaSource;
+      String sourceCode;
+      Scanner scanner;
+      String currentToken;
+
+      javaSource = new JavaSource("TestClass");
+      sourceCode = "@NotNull(groups";
+      javaSource.setSourceCode(sourceCode);
+      scanner = Examiner.getSourceCodeScanner(javaSource.getSourceCode());
+      currentToken = scanner.next(); // now @NotNull((groups
+      try {
+          ExaminerImpl.scanAfterClosedParenthesis(currentToken, scanner);
+      } catch (IllegalArgumentException iae) {
+          assertEquals("Insufficient number of tokens to scan after closed parenthesis", iae.getMessage());
+      }
+   }
+
+   @Test
    public void testJumpOverJavaToken() {
       JavaSource javaSource;
       String sourceCode;


### PR DESCRIPTION
Examiner.java calls 'scanner.next()' on 'java.util.Scanner scanner' without checking
if there are more elements. Because the scanner is built from the JavaSource parameter
that can be invalid (e.g., no token after opening parenthesis), this can lead to a runtime exception
without a useful error message. This pull request adds an error message and a test.